### PR TITLE
Use DerNull.Instance in PKCS#1 DigestInfo algorihtm params

### DIFF
--- a/src/Pkcs11Admin/Utils.cs
+++ b/src/Pkcs11Admin/Utils.cs
@@ -105,7 +105,7 @@ namespace Net.Pkcs11Admin
         public static byte[] CreateDigestInfo(byte[] hash, string hashOid)
         {
             DerObjectIdentifier derObjectIdentifier = new DerObjectIdentifier(hashOid);
-            AlgorithmIdentifier algorithmIdentifier = new AlgorithmIdentifier(derObjectIdentifier, null);
+            AlgorithmIdentifier algorithmIdentifier = new AlgorithmIdentifier(derObjectIdentifier, DerNull.Instance);
             DigestInfo digestInfo = new DigestInfo(algorithmIdentifier, hash);
             return digestInfo.GetDerEncoded();
         }


### PR DESCRIPTION
Need the null value in the der sequence for OpenSSL to verity the signature. Otherwize the verification will fail.